### PR TITLE
use puppet_gem provider instead of just gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What this module do
 
-Install puppetlabs bolt with ruby gems.
+Install puppetlabs bolt with ruby gems, using (by default) the Puppet ruby build.
 
 It also supports a hack that allows to use GSS-API with SSH in bolt.
 
@@ -33,6 +33,11 @@ class { '::bolt':
 }
 ```
 
+Hiera works as well.
+
+If you want to use system ruby instead of puppet ruby, you can set
+`bolt::provider: gem`.  (Default is `puppet_gem`.)
+
 ## Support / Limitations
 
 This module is not intended to be supported on a long term. We know that this is an ugly hack and we plan to drop this module
@@ -43,3 +48,4 @@ You can still fill an issue or submit pull requests if you'd like to share !
 ## Contributor
 
 * Remi Ferrand for IN2P3 Computing Centre, CNRS
+* Tim Skirvin for Fermi National Accelerator Laboratory

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@
 class bolt(
   String $package_name = 'bolt',
   String $package_ensure = 'latest',
-  String $package_provider = 'gem',
+  String $package_provider = 'puppet_gem',
   String $hack_script_path = '/var/tmp/hack_bolt_script.sh',
   Array[String] $bolt_ssh_auth_methods = ['gssapi-with-mic', 'publickey', 'password', 'keyboard-interactive'],
   Boolean $hack_bolt_to_allow_ssh_gssapi = false
@@ -16,7 +16,7 @@ class bolt(
   if ($hack_bolt_to_allow_ssh_gssapi == true) {
     package { 'net-ssh-krb':
       ensure   => 'latest',
-      provider => 'gem'
+      provider => $package_provider
     }
 
     file { $hack_script_path:

--- a/templates/bolt_support_gssapi_hack.erb
+++ b/templates/bolt_support_gssapi_hack.erb
@@ -2,6 +2,8 @@
 #
 # File managed by Puppet
 #
+export PATH=/opt/puppetlabs/puppet/bin:$PATH
+
 ruby_gem_install_dir=$(gem environment  | awk '/INSTALLATION DIRECTORY: / { print $4; }')
 if [ -z "$ruby_gem_install_dir" ]
 then


### PR DESCRIPTION
It's necessary to use the puppet ruby on some systems, rather than system ruby.  The `puppet_gem` provider supports that cleanly.

